### PR TITLE
receive-pack.c: should prevent object merging when all commands failed

### DIFF
--- a/builtin/receive-pack.c
+++ b/builtin/receive-pack.c
@@ -1959,6 +1959,15 @@ static void execute_commands(struct command *commands,
 	}
 
 	/*
+	 * If there is no command ready to run, should return directly to destroy
+	 * temporary data in the quarantine area.
+	 */
+	for (cmd = commands; cmd && cmd->error_string; cmd = cmd->next)
+		; /* nothing */
+	if (!cmd)
+		return;
+
+	/*
 	 * Now we'll start writing out refs, which means the objects need
 	 * to be in their final positions so that other processes can see them.
 	 */

--- a/t/t5516-fetch-push.sh
+++ b/t/t5516-fetch-push.sh
@@ -1809,4 +1809,12 @@ test_expect_success 'refuse fetch to current branch of bare repository worktree'
 	git -C bare.git fetch -u .. HEAD:wt
 '
 
+test_expect_success 'refuse to push a hidden ref, and make sure do not pollute the repository' '
+	mk_empty testrepo &&
+	git -C testrepo config receive.hiderefs refs/hidden &&
+	git -C testrepo config receive.unpackLimit 1 &&
+	test_must_fail git push testrepo HEAD:refs/hidden/foo &&
+	test_dir_is_empty testrepo/.git/objects/pack
+'
+
 test_done


### PR DESCRIPTION
During the receive-pack process, only failure of the pre-receive check prevents
object merging. But there has one case that all commands in the receive-pack
are marked as errors, and these errors are not marked by pre-receive or not by
pre-receive. In this case, the object to be merged is invalid, and the object
merging, in this case, should be rejected to reduce the problem of object
leakage caused by hidden ref (Do not allow references to be updated, but merge
objects into the repository)

Signed-off-by: bojun.cbj <bojun.cbj@alibaba-inc.com>

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use GitGitGadget (https://gitgitgadget.github.io/)
to conveniently send your Pull Requests commits to our mailing list.

Please read the "guidelines for contributing" linked above!
